### PR TITLE
fixes key error when using version and account usage calls

### DIFF
--- a/cicero/cicero_response_classes.py
+++ b/cicero/cicero_response_classes.py
@@ -1419,8 +1419,8 @@ class ResponseObject(AbstractCiceroObject):
             self.results = DistrictTypeResultsObject(r)
         elif 'credit_balance' in r:
             self.results = AccountCreditsRemainingResultsObject(r)
-	elif 'version' in r:
-	    self.results = VersionObject(r)
+        elif 'version' in r:
+            self.results = VersionObject(r)
         elif isinstance(r, list) and 'activity_types' in r[0]:
             self.results = [AccountUsageObject(month) for month in r]
 


### PR DESCRIPTION
When using the get_version() method, we were getting an error on line 1422 - "r" isn't a list except on an /account/usage call, so checking "r[0]" on a dict was breaking.

Solution: re-order the elif statements so the /account/usage case is checked last, and also add an isinstance() check on whether or not "r" is a list.
